### PR TITLE
Show original error when failing to require a package

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = function (dir) {
         task();
       }
     } catch (err) {
-      throw new Error('Failed to require task at ' + path);
+      throw new Error('Failed to require task at ' + path + ' due to the following error: ' + err.toString());
     }
   });
 };


### PR DESCRIPTION
When a package fails to be required, it's very hard to know the root cause.

This PR shows the original thrown error so it is easier to debug.

I'm not sure the error message is cool, I'm not a native english speaker :)
